### PR TITLE
Fix error in 'use-brace-expansion' rule

### DIFF
--- a/rules/use-brace-expansion.js
+++ b/rules/use-brace-expansion.js
@@ -21,7 +21,7 @@ module.exports = function(context) {
 
       if (ember.isComputedProp(node)) {
         var properties = node.arguments
-          .filter(arg => utils.isLiteral(arg))
+          .filter(arg => utils.isLiteral(arg) && typeof arg.value === 'string')
           .map(e => e.value.split('.'))
           .filter(e => e.length > 1)
           .map(e => e[0])

--- a/test/use-brace-expansion.js
+++ b/test/use-brace-expansion.js
@@ -18,6 +18,7 @@ eslintTester.run('use-brace-expansion', rule, {
     { code: '{ test: computed(function() {}) }' },
     { code: '{ test: computed("a.test", "b.test", function() {}) }' },
     { code: '{ test: computed("a.{test,test2}", "b", function() {}) }' },
+    { code: "{ test: Ember.computed.filterBy('a', 'b', false) }"},
   ],
   invalid: [
     {


### PR DESCRIPTION
The test fails with this error:
```
  1) use-brace-expansion valid { test: Ember.computed.filterBy('a', 'b', false) }:
     TypeError: e.value.split is not a function
      at CallExpression.node.arguments.filter.map.e (rules/use-brace-expansion.js:9:954)
      at Array.map (native)
      at EventEmitter.CallExpression (rules/use-brace-expansion.js:9:892)
      at NodeEventGenerator.enterNode (node_modules/eslint/lib/util/node-event-generator.js:39:22)
      at CodePathAnalyzer.enterNode (node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:607:23)
      at CommentEventGenerator.enterNode (node_modules/eslint/lib/util/comment-event-generator.js:97:23)
      at Controller.enter (node_modules/eslint/lib/eslint.js:928:36)
      at Controller.__execute (node_modules/estraverse/estraverse.js:397:31)
```

The rule fails on this AST node:
```
Node {
  type: 'Literal',
  start: 828,
  end: 833,
  loc:
   SourceLocation {
     start: Position { line: 25, column: 62 },
     end: Position { line: 25, column: 67 } },
  range: [ 828, 833 ],
  value: false,
  raw: 'false' }
```