### PR TITLE
README: Remove `ember-cli-eslint` requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 
 > An ESlint plugin that provides set of rules for Ember Applications based on commonly known good practices.
 
-## ❗️ Requirements
-
-You need to have `ember-cli-eslint` installed in your app. [More info here](https://github.com/ember-cli/ember-cli-eslint).
-
 ## 🚀 Usage
 
 ### 1. Install plugin

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 > An ESlint plugin that provides set of rules for Ember Applications based on commonly known good practices.
 
+## ❗️ Requirements
+
+[ESLint](http://eslint.org/) is required to use this plugin.
+
 ## 🚀 Usage
 
 ### 1. Install plugin


### PR DESCRIPTION
Let's remove `ember-cli-eslint` requirement mention from README - it's not necessary to use the plugin by any means, and we certainly can assume some people only linting code within text editor (for example).