### PR TITLE
Report correct positions for "order-in-*" rules

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -32,31 +32,42 @@ module.exports = function(context) {
   }
 };
 
+const ORDER = [
+  'service',
+  'property',
+  'single-line-function',
+  'multi-line-function',
+  'observer',
+  'lifecycle-hook',
+  'actions',
+  'method',
+  'unknown',
+];
+
 function ComponentPropertyInfo(node) {
   this.node = node;
-  this.order = getOrderValue(node);
+  this.type = this._getType();
+  this.order = ORDER.indexOf(this.type);
 }
 
-function getOrderValue(property) {
-  var val = null;
-
-  if (ember.isInjectedServiceProp(property.value)) {
-    val = 10;
-  } else if (ember.isCustomProp(property)) {
-    val = 20;
-  } else if (ember.isSingleLineFn(property)) {
-    val = 30;
-  } else if (ember.isMultiLineFn(property)) {
-    val = 40;
-  } else if (ember.isObserverProp(property.value)) {
-    val = 50;
-  } else if (ember.isComponentLifecycleHook(property)) {
-    val = 60;
-  } else if (ember.isActionsProp(property)) {
-    val = 70;
-  } else if (ember.isComponentCustomFunction(property)) {
-    val = 80;
+ComponentPropertyInfo.prototype._getType = function() {
+  if (ember.isInjectedServiceProp(this.node.value)) {
+    return 'service';
+  } else if (ember.isCustomProp(this.node)) {
+    return 'property';
+  } else if (ember.isSingleLineFn(this.node)) {
+    return 'single-line-function';
+  } else if (ember.isMultiLineFn(this.node)) {
+    return 'multi-line-function';
+  } else if (ember.isObserverProp(this.node.value)) {
+    return 'observer';
+  } else if (ember.isComponentLifecycleHook(this.node)) {
+    return 'lifecycle-hook';
+  } else if (ember.isActionsProp(this.node)) {
+    return 'actions';
+  } else if (ember.isComponentCustomFunction(this.node)) {
+    return 'method';
+  } else {
+    return 'unknown';
   }
-
-  return val;
-}
+};

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var utils = require('../utils/utils');
 var ember = require('../utils/ember');
 
 //------------------------------------------------------------------------------
@@ -22,11 +21,14 @@ module.exports = function(context) {
         return new ComponentPropertyInfo(property);
       });
 
-      var unorderedProperty = utils.findUnorderedProperty(properties);
-
-      if (unorderedProperty) {
-        report(unorderedProperty.node);
-      }
+      var maxOrder = -1;
+      properties.forEach(function(property) {
+        if (property.order < maxOrder) {
+          report(property.node);
+        } else {
+          maxOrder = property.order;
+        }
+      });
     }
   }
 };

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var ember = require('../utils/ember');
+var reportUnorderedProperties = require('../utils/property-order').reportUnorderedProperties;
 
 //------------------------------------------------------------------------------
 // Organizing - Organize your components and keep order in objects
@@ -11,37 +12,14 @@ module.exports = function(context) {
     CallExpression: function(node) {
       if (!ember.isEmberComponent(node)) return;
 
-      var maxOrder = -1;
-      var firstPropertyOfType = {};
+      reportUnorderedProperties(node, context, function(property) {
+        var type = toType(property);
 
-      ember.getModuleProperties(node).forEach(function(property) {
-        var info = new ComponentPropertyInfo(property);
-
-        // check if this property should be moved further upwards
-        if (info.order < maxOrder) {
-
-          // look for correct position to insert this property
-          for (var i = info.order + 1; i < ORDER.length; i++) {
-            var firstPropertyOfNextType = firstPropertyOfType[i];
-            if (firstPropertyOfNextType) {
-              break;
-            }
-          }
-
-          var typeName = info.name;
-          var nextTypeName = firstPropertyOfNextType.name;
-          var nextSourceLine = firstPropertyOfNextType.node.loc.start.line;
-
-          context.report(property,
-            `The ${typeName} should be above the ${nextTypeName} on line ${nextSourceLine}`);
-
-        } else {
-          maxOrder = info.order;
-
-          if (!(info.order in firstPropertyOfType)) {
-            firstPropertyOfType[info.order] = info;
-          }
-        }
+        return {
+          node: property,
+          name: NAMES[type],
+          order: ORDER.indexOf(type)
+        };
       });
     }
   }
@@ -71,15 +49,7 @@ const NAMES = {
   'unknown': 'unknown property type',
 };
 
-function ComponentPropertyInfo(node) {
-  var type = this._getType(node);
-
-  this.node = node;
-  this.name = NAMES[type];
-  this.order = ORDER.indexOf(type);
-}
-
-ComponentPropertyInfo.prototype._getType = function(node) {
+function toType(node) {
   if (ember.isInjectedServiceProp(node.value)) {
     return 'service';
   } else if (ember.isCustomProp(node)) {
@@ -99,4 +69,4 @@ ComponentPropertyInfo.prototype._getType = function(node) {
   } else {
     return 'unknown';
   }
-};
+}

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -20,10 +20,7 @@ module.exports = function(context) {
 
       var properties = ember.getModuleProperties(node);
       var mappedProperties = properties.map(function(property) {
-        return {
-          node: property,
-          order: getOrderValue(property)
-        };
+        return new ComponentPropertyInfo(property);
       });
 
       var unorderedProperty = utils.findUnorderedProperty(mappedProperties);
@@ -34,6 +31,11 @@ module.exports = function(context) {
     }
   }
 };
+
+function ComponentPropertyInfo(node) {
+  this.node = node;
+  this.order = getOrderValue(node);
+}
 
 function getOrderValue(property) {
   var val = null;

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -7,12 +7,6 @@ var ember = require('../utils/ember');
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-  var message = 'Check order of properties';
-
-  function report(node) {
-    context.report(node, message);
-  };
-
   return {
     CallExpression: function(node) {
       if (!ember.isEmberComponent(node)) return;

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -72,10 +72,11 @@ const NAMES = {
 };
 
 function ComponentPropertyInfo(node) {
+  var type = this._getType(node);
+
   this.node = node;
-  this.type = this._getType(node);
-  this.name = NAMES[this.type];
-  this.order = ORDER.indexOf(this.type);
+  this.name = NAMES[type];
+  this.order = ORDER.indexOf(type);
 }
 
 ComponentPropertyInfo.prototype._getType = function(node) {

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -17,37 +17,35 @@ module.exports = function(context) {
     CallExpression: function(node) {
       if (!ember.isEmberComponent(node)) return;
 
-      var properties = ember.getModuleProperties(node).map(function(property) {
-        return new ComponentPropertyInfo(property);
-      });
-
       var maxOrder = -1;
       var firstPropertyOfType = {};
-      properties.forEach(function(property) {
+
+      ember.getModuleProperties(node).forEach(function(property) {
+        var info = new ComponentPropertyInfo(property);
 
         // check if this property should be moved further upwards
-        if (property.order < maxOrder) {
+        if (info.order < maxOrder) {
 
           // look for correct position to insert this property
-          for (var i = property.order + 1; i < ORDER.length; i++) {
+          for (var i = info.order + 1; i < ORDER.length; i++) {
             var firstPropertyOfNextType = firstPropertyOfType[i];
             if (firstPropertyOfNextType) {
               break;
             }
           }
 
-          var typeName = property.name;
+          var typeName = info.name;
           var nextTypeName = firstPropertyOfNextType.name;
           var nextSourceLine = firstPropertyOfNextType.node.loc.start.line;
 
-          context.report(property.node,
+          context.report(property,
             `The ${typeName} should be above the ${nextTypeName} on line ${nextSourceLine}`);
 
         } else {
-          maxOrder = property.order;
+          maxOrder = info.order;
 
-          if (!(property.order in firstPropertyOfType)) {
-            firstPropertyOfType[property.order] = property;
+          if (!(info.order in firstPropertyOfType)) {
+            firstPropertyOfType[info.order] = info;
           }
         }
       });
@@ -81,27 +79,27 @@ const NAMES = {
 
 function ComponentPropertyInfo(node) {
   this.node = node;
-  this.type = this._getType();
+  this.type = this._getType(node);
   this.name = NAMES[this.type];
   this.order = ORDER.indexOf(this.type);
 }
 
-ComponentPropertyInfo.prototype._getType = function() {
-  if (ember.isInjectedServiceProp(this.node.value)) {
+ComponentPropertyInfo.prototype._getType = function(node) {
+  if (ember.isInjectedServiceProp(node.value)) {
     return 'service';
-  } else if (ember.isCustomProp(this.node)) {
+  } else if (ember.isCustomProp(node)) {
     return 'property';
-  } else if (ember.isSingleLineFn(this.node)) {
+  } else if (ember.isSingleLineFn(node)) {
     return 'single-line-function';
-  } else if (ember.isMultiLineFn(this.node)) {
+  } else if (ember.isMultiLineFn(node)) {
     return 'multi-line-function';
-  } else if (ember.isObserverProp(this.node.value)) {
+  } else if (ember.isObserverProp(node.value)) {
     return 'observer';
-  } else if (ember.isComponentLifecycleHook(this.node)) {
+  } else if (ember.isComponentLifecycleHook(node)) {
     return 'lifecycle-hook';
-  } else if (ember.isActionsProp(this.node)) {
+  } else if (ember.isActionsProp(node)) {
     return 'actions';
-  } else if (ember.isComponentCustomFunction(this.node)) {
+  } else if (ember.isComponentCustomFunction(node)) {
     return 'method';
   } else {
     return 'unknown';

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -18,12 +18,11 @@ module.exports = function(context) {
     CallExpression: function(node) {
       if (!ember.isEmberComponent(node)) return;
 
-      var properties = ember.getModuleProperties(node);
-      var mappedProperties = properties.map(function(property) {
+      var properties = ember.getModuleProperties(node).map(function(property) {
         return new ComponentPropertyInfo(property);
       });
 
-      var unorderedProperty = utils.findUnorderedProperty(mappedProperties);
+      var unorderedProperty = utils.findUnorderedProperty(properties);
 
       if (unorderedProperty) {
         report(unorderedProperty.node);

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -3,28 +3,6 @@
 var ember = require('../utils/ember');
 var reportUnorderedProperties = require('../utils/property-order').reportUnorderedProperties;
 
-//------------------------------------------------------------------------------
-// Organizing - Organize your components and keep order in objects
-//------------------------------------------------------------------------------
-
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (!ember.isEmberComponent(node)) return;
-
-      reportUnorderedProperties(node, context, function(property) {
-        var type = toType(property);
-
-        return {
-          node: property,
-          name: NAMES[type],
-          order: ORDER.indexOf(type)
-        };
-      });
-    }
-  }
-};
-
 const ORDER = [
   'service',
   'property',
@@ -70,3 +48,25 @@ function toType(node) {
     return 'unknown';
   }
 }
+
+//------------------------------------------------------------------------------
+// Organizing - Organize your components and keep order in objects
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+  return {
+    CallExpression: function(node) {
+      if (!ember.isEmberComponent(node)) return;
+
+      reportUnorderedProperties(node, context, function(property) {
+        var type = toType(property);
+
+        return {
+          node: property,
+          name: NAMES[type],
+          order: ORDER.indexOf(type)
+        };
+      });
+    }
+  }
+};

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -22,11 +22,33 @@ module.exports = function(context) {
       });
 
       var maxOrder = -1;
+      var firstPropertyOfType = {};
       properties.forEach(function(property) {
+
+        // check if this property should be moved further upwards
         if (property.order < maxOrder) {
-          report(property.node);
+
+          // look for correct position to insert this property
+          for (var i = property.order + 1; i < ORDER.length; i++) {
+            var firstPropertyOfNextType = firstPropertyOfType[i];
+            if (firstPropertyOfNextType) {
+              break;
+            }
+          }
+
+          var typeName = NAMES[property.type];
+          var nextTypeName = NAMES[firstPropertyOfNextType.type];
+          var nextSourceLine = firstPropertyOfNextType.node.loc.start.line;
+
+          context.report(property.node,
+            `The ${typeName} should be above the ${nextTypeName} on line ${nextSourceLine}`);
+
         } else {
           maxOrder = property.order;
+
+          if (!(property.order in firstPropertyOfType)) {
+            firstPropertyOfType[property.order] = property;
+          }
         }
       });
     }
@@ -44,6 +66,18 @@ const ORDER = [
   'method',
   'unknown',
 ];
+
+const NAMES = {
+  'service': 'service injection',
+  'property': 'property',
+  'single-line-function': 'single-line function',
+  'multi-line-function': 'multi-line function',
+  'observer': 'observer',
+  'lifecycle-hook': 'lifecycle hook',
+  'actions': 'actions hash',
+  'method': 'custom method',
+  'unknown': 'unknown property type',
+};
 
 function ComponentPropertyInfo(node) {
   this.node = node;

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -36,8 +36,8 @@ module.exports = function(context) {
             }
           }
 
-          var typeName = NAMES[property.type];
-          var nextTypeName = NAMES[firstPropertyOfNextType.type];
+          var typeName = property.name;
+          var nextTypeName = firstPropertyOfNextType.name;
           var nextSourceLine = firstPropertyOfNextType.node.loc.start.line;
 
           context.report(property.node,
@@ -82,6 +82,7 @@ const NAMES = {
 function ComponentPropertyInfo(node) {
   this.node = node;
   this.type = this._getType();
+  this.name = NAMES[this.type];
   this.order = ORDER.indexOf(this.type);
 }
 

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -1,60 +1,73 @@
 'use strict';
 
-var utils = require('../utils/utils');
 var ember = require('../utils/ember');
+var reportUnorderedProperties = require('../utils/property-order').reportUnorderedProperties;
+
+const ORDER = [
+  'service',
+  'default-property',
+  'property',
+  'single-line-function',
+  'multi-line-function',
+  'observer',
+  'actions',
+  'method',
+  'unknown',
+];
+
+const NAMES = {
+  'service': 'service injection',
+  'default-property': 'default property',
+  'property': 'property',
+  'single-line-function': 'single-line function',
+  'multi-line-function': 'multi-line function',
+  'observer': 'observer',
+  'actions': 'actions hash',
+  'method': 'custom method',
+  'unknown': 'unknown property type',
+};
+
+function toType(node) {
+  if (ember.isInjectedServiceProp(node.value)) {
+    return 'service';
+  } else if (ember.isControllerDefaultProp(node)) {
+    return 'default-property';
+  } else if (ember.isCustomProp(node)) {
+    return 'property';
+  } else if (ember.isSingleLineFn(node)) {
+    return 'single-line-function';
+  } else if (ember.isMultiLineFn(node)) {
+    return 'multi-line-function';
+  } else if (ember.isObserverProp(node.value)) {
+    return 'observer';
+  } else if (ember.isActionsProp(node)) {
+    return 'actions';
+  } else if (ember.isFunctionExpression(node.value)) {
+    return 'method';
+  } else {
+    return 'unknown';
+  }
+}
 
 //------------------------------------------------------------------------------
 // Organizing - Organize your routes and keep order in objects
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-  var message = 'Check order of properties';
-
-  function report(node) {
-    context.report(node, message);
-  }
-
   return {
     CallExpression: function(node) {
       if (!ember.isEmberController(node)) return;
 
-      var properties = ember.getModuleProperties(node);
-      var mappedProperties = properties.map(function(property) {
+      reportUnorderedProperties(node, context, function(property) {
+        var type = toType(property);
+
         return {
           node: property,
-          order: getOrderValue(property)
+          name: NAMES[type],
+          order: ORDER.indexOf(type)
         };
       });
-
-      var unorderedProperty = utils.findUnorderedProperty(mappedProperties);
-
-      if (unorderedProperty) {
-        report(unorderedProperty.node);
-      }
     }
   };
 };
 
-function getOrderValue(property) {
-  var val = null;
-
-  if (ember.isInjectedServiceProp(property.value)) {
-    val = 10;
-  } else if (ember.isControllerDefaultProp(property)) {
-    val = 20;
-  } else if (ember.isCustomProp(property)) {
-    val = 30;
-  } else if (ember.isSingleLineFn(property)) {
-    val = 40;
-  } else if (ember.isMultiLineFn(property)) {
-    val = 50;
-  } else if (ember.isObserverProp(property.value)) {
-    val = 60;
-  } else if (ember.isActionsProp(property)) {
-    val = 70;
-  } else if (ember.isFunctionExpression(property.value)) {
-    val = 80;
-  }
-
-  return val;
-}

--- a/lib/rules/order-in-models.js
+++ b/lib/rules/order-in-models.js
@@ -1,7 +1,37 @@
 'use strict';
 
-var utils = require('../utils/utils');
 var ember = require('../utils/ember');
+var reportUnorderedProperties = require('../utils/property-order').reportUnorderedProperties;
+
+const ORDER = [
+  'attribute',
+  'relationship',
+  'single-line-function',
+  'multi-line-function',
+  'other',
+];
+
+const NAMES = {
+  'attribute': 'attribute',
+  'relationship': 'relationship',
+  'single-line-function': 'single-line function',
+  'multi-line-function': 'multi-line function',
+  'other': 'property',
+};
+
+function toType(node) {
+  if (ember.isModule(node.value, 'attr', 'DS')) {
+    return 'attribute';
+  } else if (ember.isRelation(node)) {
+    return 'relationship';
+  } else if (ember.isSingleLineFn(node)) {
+    return 'single-line-function';
+  } else if (ember.isMultiLineFn(node)) {
+    return 'multi-line-function';
+  } else {
+    return 'other';
+  }
+}
 
 //------------------------------------------------------------------------------
 // Organizing - Organize your models
@@ -9,47 +39,19 @@ var ember = require('../utils/ember');
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-  var message = 'Check order of properties';
-
-  function report(node) {
-    context.report(node, message);
-  };
-
   return {
     CallExpression: function(node) {
       if (!ember.isDSModel(node)) return;
 
-      var properties = ember.getModuleProperties(node);
-      var mappedProperties = properties.map(function(property) {
+      reportUnorderedProperties(node, context, function(property) {
+        var type = toType(property);
+
         return {
           node: property,
-          order: getOrderValue(property)
+          name: NAMES[type],
+          order: ORDER.indexOf(type)
         };
       });
-
-      var unorderedProperty = utils.findUnorderedProperty(mappedProperties);
-
-      if (unorderedProperty) {
-        report(unorderedProperty.node);
-      }
     }
   };
 };
-
-function getOrderValue(property) {
-  var val = null;
-
-  if (ember.isModule(property.value, 'attr', 'DS')) {
-    val = 10;
-  } else if (ember.isRelation(property)) {
-    val = 20;
-  } else if (ember.isSingleLineFn(property)) {
-    val = 30;
-  } else if (ember.isMultiLineFn(property)) {
-    val = 40;
-  } else {
-    val = 50;
-  }
-
-  return val;
-}

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -1,7 +1,50 @@
 'use strict';
 
-var utils = require('../utils/utils');
 var ember = require('../utils/ember');
+var reportUnorderedProperties = require('../utils/property-order').reportUnorderedProperties;
+
+const ORDER = [
+  'service',
+  'default-property',
+  'property',
+  'model',
+  'lifecycle-hook',
+  'actions',
+  'method',
+  'unknown',
+];
+
+const NAMES = {
+  'service': 'service injection',
+  'default-property': 'default property',
+  'property': 'property',
+  'model': 'model hook',
+  'lifecycle-hook': 'lifecycle hook',
+  'actions': 'actions hash',
+  'method': 'custom method',
+  'unknown': 'unknown property type',
+};
+
+function toType(node) {
+
+  if (ember.isInjectedServiceProp(node.value)) {
+    return 'service';
+  } else if (ember.isRouteDefaultProp(node)) {
+    return 'default-property';
+  } else if (ember.isCustomProp(node)) {
+    return 'property';
+  } else if (ember.isModelProp(node)) {
+    return 'model';
+  } else if (ember.isRouteDefaultMethod(node)) {
+    return 'lifecycle-hook';
+  } else if (ember.isActionsProp(node)) {
+    return 'actions';
+  } else if (ember.isRouteCustomFunction(node)) {
+    return 'method';
+  } else {
+    return 'unknown';
+  }
+}
 
 //------------------------------------------------------------------------------
 // Organizing - Organize your routes and keep order in objects
@@ -18,41 +61,15 @@ module.exports = function(context) {
     CallExpression: function(node) {
       if (!ember.isEmberRoute(node)) return;
 
-      var properties = ember.getModuleProperties(node);
-      var mappedProperties = properties.map(function(property) {
+      reportUnorderedProperties(node, context, function(property) {
+        var type = toType(property);
+
         return {
           node: property,
-          order: getOrderValue(property)
+          name: NAMES[type],
+          order: ORDER.indexOf(type)
         };
       });
-
-      var unorderedProperty = utils.findUnorderedProperty(mappedProperties);
-
-      if (unorderedProperty) {
-        report(unorderedProperty.node);
-      }
     }
   };
 };
-
-function getOrderValue(property) {
-  var val = null;
-
-  if (ember.isInjectedServiceProp(property.value)) {
-    val = 10;
-  } else if (ember.isRouteDefaultProp(property)) {
-    val = 20;
-  } else if (ember.isCustomProp(property)) {
-    val = 30;
-  } else if (ember.isModelProp(property)) {
-    val = 40;
-  } else if (ember.isRouteDefaultMethod(property)) {
-    val = 50;
-  } else if (ember.isActionsProp(property)) {
-    val = 60;
-  } else if (ember.isRouteCustomFunction(property)) {
-    val = 70;
-  }
-
-  return val;
-}

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -1,0 +1,40 @@
+var ember = require('./ember');
+
+module.exports = {
+  reportUnorderedProperties: reportUnorderedProperties
+};
+
+function reportUnorderedProperties(node, context, toPropertyInfo) {
+  var maxOrder = -1;
+  var firstPropertyOfType = {};
+
+  ember.getModuleProperties(node).forEach(function(property) {
+    var info = toPropertyInfo(property);
+
+    // check if this property should be moved further upwards
+    if (info.order < maxOrder) {
+
+      // look for correct position to insert this property
+      for (var i = info.order + 1; i <= maxOrder; i++) {
+        var firstPropertyOfNextType = firstPropertyOfType[i];
+        if (firstPropertyOfNextType) {
+          break;
+        }
+      }
+
+      var typeName = info.name;
+      var nextTypeName = firstPropertyOfNextType.name;
+      var nextSourceLine = firstPropertyOfNextType.node.loc.start.line;
+
+      context.report(property,
+        `The ${typeName} should be above the ${nextTypeName} on line ${nextSourceLine}`);
+
+    } else {
+      maxOrder = info.order;
+
+      if (!(info.order in firstPropertyOfType)) {
+        firstPropertyOfType[info.order] = info;
+      }
+    }
+  });
+}

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -15,169 +15,416 @@ var eslintTester = new RuleTester();
 eslintTester.run('order-in-components', rule, {
   valid: [
     {
-      code: 'export default Component.extend();',
+      code: `export default Component.extend();`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({role: "sloth", vehicle: alias("car"), levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      code: `export default Component.extend({
+        role: "sloth",
+
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({role: "sloth", levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      code: `export default Component.extend({
+        role: "sloth",
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      code: `export default Component.extend({
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend(TestMixin, {levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      code: `export default Component.extend(TestMixin, {
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend(TestMixin, TestMixin2, {levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      code: `export default Component.extend(TestMixin, TestMixin2, {
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({abc: Ember.inject.service(), def: inject.service(), ghi: service(), role: "sloth", levelOfHappiness: computed("attitude", "health", () => {\n})});',
+      code: `export default Component.extend({
+        abc: Ember.inject.service(),
+        def: inject.service(),
+        ghi: service(),
+
+        role: "sloth",
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({role: "sloth", abc: [], def: {}, ghi: alias("def")});',
+      code: `export default Component.extend({
+        role: "sloth",
+        abc: [],
+        def: {},
+
+        ghi: alias("def")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), abc: Ember.observer("aaaa", () => {\n}), def: observer("aaaa", () => {\n}), actions: {}});',
+      code: `export default Component.extend({
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        abc: Ember.observer("aaaa", () => {
+        }),
+
+        def: observer("aaaa", () => {
+        }),
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({abc: observer("aaaa", () => {\n}), init() {\n}, actions: {}, customFunction() {\n}});',
+      code: `export default Component.extend({
+        abc: observer("aaaa", () => {
+        }),
+
+        init() {
+        },
+
+        actions: {},
+
+        customFunction() {
+        }
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({igh: service(), abc: [], def: true, singleComp: alias("abc"), multiComp: computed(() => {\n}), obs: observer("aaa", () => {\n}), init() {\n}, actions: {}, customFunc() {\n}});',
+      code: `export default Component.extend({
+        igh: service(),
+
+        abc: [],
+        def: true,
+
+        singleComp: alias("abc"),
+
+        multiComp: computed(() => {
+        }),
+
+        obs: observer("aaa", () => {
+        }),
+
+        init() {
+        },
+
+        actions: {},
+
+        customFunc() {
+        }});`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({init() {\n}, didReceiveAttrs() {\n}, willRender() {\n}, didInsertElement() {\n}, didRender() {\n}, didUpdateAttrs() {\n}, willUpdate() {\n}, didUpdate() {\n}, willDestroyElement() {\n}, willClearRender() {\n}, didDestroyElement() {\n}, actions: {}});',
+      code: `export default Component.extend({
+        init() {
+        },
+        didReceiveAttrs() {
+        },
+        willRender() {
+        },
+        didInsertElement() {
+        },
+        didRender() {
+        },
+        didUpdateAttrs() {
+        },
+        willUpdate() {
+        },
+        didUpdate() {
+        },
+        willDestroyElement() {
+        },
+        willClearRender() {
+        },
+        didDestroyElement() {
+        },
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({test: service(), didReceiveAttrs() {\n}, tSomeAction: task(function* (url) {\n})});',
+      code: `export default Component.extend({
+        test: service(),
+
+        didReceiveAttrs() {
+        },
+
+        tSomeAction: task(function* (url) {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({test: service(), test2: computed.equal("asd", "qwe"), didReceiveAttrs() {\n}, tSomeAction: task(function* (url) {\n}).restartable()});',
+      code: `export default Component.extend({
+        test: service(),
+
+        test2: computed.equal("asd", "qwe"),
+
+        didReceiveAttrs() {
+        },
+
+        tSomeAction: task(function* (url) {
+        }).restartable()
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({test: service(), didReceiveAttrs() {\n}, tSomeAction: task(function* (url) {\n}), _anotherPrivateFnc() {\n}});',
+      code: `export default Component.extend({
+        test: service(),
+
+        didReceiveAttrs() {
+        },
+
+        tSomeAction: task(function* (url) {
+        }),
+
+        _anotherPrivateFnc() {
+        }
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({classNameBindings: ["filterDateSelectClass"], content: [], currentMonthEndDate: null, currentMonthStartDate: null, optionValuePath: "value", optionLabelPath: "label", typeOfDate: null, action: K});',
+      code: `export default Component.extend({
+        classNameBindings: ["filterDateSelectClass"],
+        content: [],
+        currentMonthEndDate: null,
+        currentMonthStartDate: null,
+        optionValuePath: "value",
+        optionLabelPath: "label",
+        typeOfDate: null,
+        action: K
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({ role: "sloth", levelOfHappiness: computed.or("asd", "qwe"), actions: {} });',
+      code: `export default Component.extend({
+        role: "sloth",
+
+        levelOfHappiness: computed.or("asd", "qwe"),
+
+        actions: {} 
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({ role: "sloth", levelOfHappiness: computed(function() {}), actions: {} });',
+      code: `export default Component.extend({ 
+        role: "sloth",
+
+        levelOfHappiness: computed(function() {}),
+
+        actions: {} 
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({ role: "sloth", levelOfHappiness: computed(function() {\n}), actions: {} });',
+      code: `export default Component.extend({
+        role: "sloth",
+
+        levelOfHappiness: computed(function() {
+        }),
+
+        actions: {} 
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
   ],
   invalid: [
     {
-      code: 'export default Component.extend({actions: {}, role: "sloth", vehicle: alias("car"), levelOfHappiness: computed("attitude", "health", () => {\n})});',
+      code: `export default Component.extend({
+        actions: {},
+
+        role: "sloth",
+
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({vehicle: alias("car"), role: "sloth", levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      code: `export default Component.extend({
+        vehicle: alias("car"),
+
+        role: "sloth",
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), vehicle: alias("car"), role: "sloth", actions: {}});',
+      code: `export default Component.extend({
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        vehicle: alias("car"),
+
+        role: "sloth",
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend(TestMixin, {levelOfHappiness: computed("attitude", "health", () => {\n}), vehicle: alias("car"), role: "sloth", actions: {}});',
+      code: `export default Component.extend(TestMixin, {
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        vehicle: alias("car"),
+
+        role: "sloth",
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend(TestMixin, TestMixin2, {levelOfHappiness: computed("attitude", "health", () => {\n}), vehicle: alias("car"), role: "sloth", actions: {}});',
+      code: `export default Component.extend(TestMixin, TestMixin2, {
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        vehicle: alias("car"),
+
+        role: "sloth",
+
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({abc: true, i18n: service()});',
+      code: `export default Component.extend({
+        abc: true,
+        i18n: service()
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({vehicle: alias("car"), i18n: service()});',
+      code: `export default Component.extend({
+        vehicle: alias("car"),
+        i18n: service()
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({levelOfHappiness: observer("attitude", "health", () => {\n}), vehicle: alias("car")});',
+      code: `export default Component.extend({
+        levelOfHappiness: observer("attitude", "health", () => {
+        }),
+        vehicle: alias("car")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({levelOfHappiness: observer("attitude", "health", () => {\n}), aaa: computed("attitude", "health", () => {\n})});',
+      code: `export default Component.extend({
+        levelOfHappiness: observer("attitude", "health", () => {
+        }),
+        aaa: computed("attitude", "health", () => {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({init() {\n}, levelOfHappiness: observer("attitude", "health", () => {\n})});',
+      code: `export default Component.extend({
+        init() {
+        },
+        levelOfHappiness: observer("attitude", "health", () => {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({actions: {}, init() {\n}});',
+      code: `export default Component.extend({
+        actions: {},
+        init() {
+        }
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({customFunc() {\n}, actions: {}});',
+      code: `export default Component.extend({
+        customFunc() {
+        },
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Component.extend({tAction: test(function() {\n}), actions: {}});',
+      code: `export default Component.extend({
+        tAction: test(function() {
+        }),
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -276,6 +276,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -292,6 +293,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -308,6 +310,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -324,6 +327,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -340,6 +344,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -350,6 +355,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -360,6 +366,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -371,6 +378,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -383,6 +391,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -395,6 +404,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -406,6 +416,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -417,6 +428,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
     {
@@ -428,6 +440,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
+        line: 2,
       }],
     },
   ]

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -275,13 +275,13 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The property should be above the actions hash on line 2',
         line: 4,
       }, {
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the actions hash on line 2',
         line: 6,
       }, {
-        message: 'Check order of properties',
+        message: 'The multi-line function should be above the actions hash on line 2',
         line: 8,
       }],
     },
@@ -298,7 +298,7 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The property should be above the single-line function on line 2',
         line: 4,
       }],
     },
@@ -315,10 +315,10 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the multi-line function on line 2',
         line: 5,
       }, {
-        message: 'Check order of properties',
+        message: 'The property should be above the multi-line function on line 2',
         line: 7,
       }],
     },
@@ -335,10 +335,10 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the multi-line function on line 2',
         line: 5,
       }, {
-        message: 'Check order of properties',
+        message: 'The property should be above the multi-line function on line 2',
         line: 7,
       }],
     },
@@ -355,10 +355,10 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the multi-line function on line 2',
         line: 5,
       }, {
-        message: 'Check order of properties',
+        message: 'The property should be above the multi-line function on line 2',
         line: 7,
       }],
     },
@@ -369,7 +369,7 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The service injection should be above the property on line 2',
         line: 3,
       }],
     },
@@ -380,7 +380,7 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The service injection should be above the single-line function on line 2',
         line: 3,
       }],
     },
@@ -392,7 +392,7 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the observer on line 2',
         line: 4,
       }],
     },
@@ -405,7 +405,7 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The multi-line function should be above the observer on line 2',
         line: 4,
       }],
     },
@@ -418,7 +418,7 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The observer should be above the lifecycle hook on line 2',
         line: 4,
       }],
     },
@@ -430,7 +430,7 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The lifecycle hook should be above the actions hash on line 2',
         line: 3,
       }],
     },
@@ -442,7 +442,7 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The actions hash should be above the custom method on line 2',
         line: 4,
       }],
     },
@@ -454,8 +454,30 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The actions hash should be above the custom method on line 2',
         line: 4,
+      }],
+    },
+    {
+      code: `export default Component.extend(TestMixin, TestMixin2, {
+        foo: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {  
+        }),
+
+        vehicle: alias("car"),
+
+        role: "sloth",
+
+        actions: {}
+      });`,
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'The single-line function should be above the multi-line function on line 4',
+        line: 7,
+      }, {
+        message: 'The property should be above the single-line function on line 2',
+        line: 9,
       }],
     },
   ]

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -276,7 +276,13 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 4,
+      }, {
+        message: 'Check order of properties',
+        line: 6,
+      }, {
+        message: 'Check order of properties',
+        line: 8,
       }],
     },
     {
@@ -293,7 +299,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 4,
       }],
     },
     {
@@ -310,7 +316,10 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 5,
+      }, {
+        message: 'Check order of properties',
+        line: 7,
       }],
     },
     {
@@ -327,7 +336,10 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 5,
+      }, {
+        message: 'Check order of properties',
+        line: 7,
       }],
     },
     {
@@ -344,7 +356,10 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 5,
+      }, {
+        message: 'Check order of properties',
+        line: 7,
       }],
     },
     {
@@ -355,7 +370,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 3,
       }],
     },
     {
@@ -366,7 +381,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 3,
       }],
     },
     {
@@ -378,7 +393,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 4,
       }],
     },
     {
@@ -391,7 +406,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 4,
       }],
     },
     {
@@ -404,7 +419,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 4,
       }],
     },
     {
@@ -416,7 +431,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 3,
       }],
     },
     {
@@ -428,7 +443,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 4,
       }],
     },
     {
@@ -440,7 +455,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
-        line: 2,
+        line: 4,
       }],
     },
   ]

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -15,60 +15,105 @@ var eslintTester = new RuleTester();
 eslintTester.run('order-in-controllers', rule, {
   valid: [
     {
-      code: 'export default Controller.extend();',
+      code: `export default Controller.extend();`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Controller.extend({currentUser: service(), queryParams: [], customProp: "test", actions: {}, _customAction() {}, _customAction2: function() {}, tSomeTask: task(function* () {}) });',
+      code: `export default Controller.extend({
+        currentUser: service(),
+        queryParams: [],
+        customProp: "test",
+        actions: {},
+        _customAction() {},
+        _customAction2: function() {},
+        tSomeTask: task(function* () {})
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Controller.extend({queryParams: [], customProp: "test", comp: computed("test", function() {}), obs: observer("asd", function() {}), actions: {} });',
+      code: `export default Controller.extend({
+        queryParams: [],
+        customProp: "test",
+        comp: computed("test", function() {}),
+        obs: observer("asd", function() {}),
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Controller.extend({customProp: "test", comp: computed("test", function() {}), comp: computed("test", function() {\n}), actions: {}, _customAction() {} });',
+      code: `export default Controller.extend({
+        customProp: "test",
+        comp: computed("test", function() {}),
+        comp2: computed("test", function() {
+        }),
+        actions: {},
+        _customAction() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
   ],
   invalid: [
     {
-      code: 'export default Controller.extend({queryParams: [], currentUser: service() });',
+      code: `export default Controller.extend({
+        queryParams: [],
+        currentUser: service()
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Controller.extend({currentUser: service(), customProp: "test", queryParams: [] });',
+      code: `export default Controller.extend({
+        currentUser: service(),
+        customProp: "test",
+        queryParams: []
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Controller.extend({queryParams: [], actions: {}, customProp: "test" });',
+      code: `export default Controller.extend({
+        queryParams: [],
+        actions: {},
+        customProp: "test"
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Controller.extend({queryParams: [], _customAction() {}, actions: {} });',
+      code: `export default Controller.extend({
+        queryParams: [],
+        _customAction() {},
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Controller.extend({test: "asd", queryParams: [], actions: {} });',
+      code: `export default Controller.extend({
+        test: "asd",
+        queryParams: [],
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Controller.extend({test: "asd", obs: observer("asd", function() {}), comp: computed("asd", function() {}), actions: {} });',
+      code: `export default Controller.extend({
+        test: "asd",
+        obs: observer("asd", function() {}),
+        comp: computed("asd", function() {}),
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -60,7 +60,8 @@ eslintTester.run('order-in-controllers', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The service injection should be above the default property on line 2',
+        line: 3
       }],
     },
     {
@@ -71,7 +72,8 @@ eslintTester.run('order-in-controllers', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The default property should be above the property on line 3',
+        line: 4
       }],
     },
     {
@@ -82,7 +84,8 @@ eslintTester.run('order-in-controllers', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The property should be above the actions hash on line 3',
+        line: 4
       }],
     },
     {
@@ -93,7 +96,8 @@ eslintTester.run('order-in-controllers', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The actions hash should be above the custom method on line 3',
+        line: 4
       }],
     },
     {
@@ -104,7 +108,8 @@ eslintTester.run('order-in-controllers', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The default property should be above the property on line 2',
+        line: 3
       }],
     },
     {
@@ -116,7 +121,8 @@ eslintTester.run('order-in-controllers', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the observer on line 3',
+        line: 4
       }],
     },
   ]

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -101,7 +101,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The attribute should be above the relationship on line 2',
+        line: 3,
       }],
     },
     {
@@ -113,7 +114,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The relationship should be above the multi-line function on line 3',
+        line: 5,
       }],
     },
     {
@@ -124,7 +126,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The attribute should be above the multi-line function on line 2',
+        line: 4,
       }],
     },
     {
@@ -136,7 +139,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The attribute should be above the relationship on line 2',
+        line: 3,
       }],
     },
     {
@@ -148,7 +152,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The relationship should be above the multi-line function on line 3',
+        line: 5,
       }],
     },
     {
@@ -159,7 +164,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The attribute should be above the multi-line function on line 2',
+        line: 4,
       }],
     },
     {
@@ -170,7 +176,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the multi-line function on line 2',
+        line: 4,
       }],
     },
     {
@@ -181,7 +188,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the multi-line function on line 2',
+        line: 4,
       }],
     },
     {
@@ -192,7 +200,8 @@ eslintTester.run('order-in-models', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The single-line function should be above the multi-line function on line 2',
+        line: 4,
       }],
     }
   ]

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -15,105 +15,181 @@ var eslintTester = new RuleTester();
 eslintTester.run('order-in-models', rule, {
   valid: [
     {
-      code: 'export default Model.extend();',
+      code: `export default Model.extend();`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Model.extend({shape: attr("string"), behaviors: hasMany("behaviour"), test: computed.alias("qwerty"), mood: computed("health", "hunger", function() {\n})});',
+      code: `export default Model.extend({
+        shape: attr("string"),
+        behaviors: hasMany("behaviour"),
+        test: computed.alias("qwerty"),
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Model.extend({behaviors: hasMany("behaviour"), mood: computed("health", "hunger", function() {\n})});',
+      code: `export default Model.extend({
+        behaviors: hasMany("behaviour"),
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Model.extend({mood: computed("health", "hunger", function() {\n})});',
+      code: `export default Model.extend({
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default DS.Model.extend({shape: DS.attr("string"), behaviors: hasMany("behaviour"), mood: computed("health", "hunger", function() {\n})});',
+      code: `export default DS.Model.extend({
+        shape: DS.attr("string"),
+        behaviors: hasMany("behaviour"),
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default DS.Model.extend({behaviors: hasMany("behaviour"), mood: computed("health", "hunger", function() {\n})});',
+      code: `export default DS.Model.extend({
+        behaviors: hasMany("behaviour"),
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default DS.Model.extend({mood: computed("health", "hunger", function() {\n})});',
+      code: `export default DS.Model.extend({
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default DS.Model.extend(TestMixin, {mood: computed("health", "hunger", function() {\n})});',
+      code: `export default DS.Model.extend(TestMixin, {
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default DS.Model.extend(TestMixin, TestMixin2, {mood: computed("health", "hunger", function() {\n})});',
+      code: `export default DS.Model.extend(TestMixin, TestMixin2, {
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default DS.Model.extend({ a: attr("string"), b: belongsTo("c", { async: false }), convertA(paramA) { \n } });',
+      code: `export default DS.Model.extend({
+        a: attr("string"),
+        b: belongsTo("c", { async: false }),
+        convertA(paramA) { 
+        }
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     }
   ],
   invalid: [
     {
-      code: 'export default Model.extend({behaviors: hasMany("behaviour"), shape: attr("string"), mood: computed("health", "hunger", function() {\n})});',
+      code: `export default Model.extend({
+        behaviors: hasMany("behaviour"),
+        shape: attr("string"),
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Model.extend({shape: attr("string"), mood: computed("health", "hunger", function() {\n}), behaviors: hasMany("behaviour")});',
+      code: `export default Model.extend({
+        shape: attr("string"),
+        mood: computed("health", "hunger", function() {
+        }),
+        behaviors: hasMany("behaviour")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Model.extend({mood: computed("health", "hunger", function() {\n}), shape: attr("string")});',
+      code: `export default Model.extend({
+        mood: computed("health", "hunger", function() {
+        }),
+        shape: attr("string")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default DS.Model.extend({behaviors: hasMany("behaviour"), shape: DS.attr("string"), mood: Ember.computed("health", "hunger", function() {\n})});',
+      code: `export default DS.Model.extend({
+        behaviors: hasMany("behaviour"),
+        shape: DS.attr("string"),
+        mood: Ember.computed("health", "hunger", function() {
+        })
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default DS.Model.extend({shape: attr("string"), mood: computed("health", "hunger", function() {\n}), behaviors: hasMany("behaviour")});',
+      code: `export default DS.Model.extend({
+        shape: attr("string"),
+        mood: computed("health", "hunger", function() {
+        }),
+        behaviors: hasMany("behaviour")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default DS.Model.extend({mood: computed("health", "hunger", function() {\n}), shape: attr("string")});',
+      code: `export default DS.Model.extend({
+        mood: computed("health", "hunger", function() {
+        }),
+        shape: attr("string")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default DS.Model.extend({mood: computed("health", "hunger", function() {\n}), test: computed.alias("qwerty")});',
+      code: `export default DS.Model.extend({
+        mood: computed("health", "hunger", function() {
+        }),
+        test: computed.alias("qwerty")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default DS.Model.extend(TestMixin, {mood: computed("health", "hunger", function() {\n}), test: computed.alias("qwerty")});',
+      code: `export default DS.Model.extend(TestMixin, {
+        mood: computed("health", "hunger", function() {
+        }),
+        test: computed.alias("qwerty")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default DS.Model.extend(TestMixin, TestMixin2, {mood: computed("health", "hunger", function() {\n}), test: computed.alias("qwerty")});',
+      code: `export default DS.Model.extend(TestMixin, TestMixin2, {
+        mood: computed("health", "hunger", function() {
+        }),
+        test: computed.alias("qwerty")
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -80,7 +80,8 @@ eslintTester.run('order-in-routes', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The service injection should be above the default property on line 2',
+        line: 3,
       }],
     },
     {
@@ -94,7 +95,8 @@ eslintTester.run('order-in-routes', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The default property should be above the property on line 2',
+        line: 3,
       }],
     },
     {
@@ -108,7 +110,11 @@ eslintTester.run('order-in-routes', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The default property should be above the property on line 2',
+        line: 3,
+      }, {
+        message: 'The model hook should be above the lifecycle hook on line 4',
+        line: 5,
       }],
     },
     {
@@ -121,7 +127,8 @@ eslintTester.run('order-in-routes', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The actions hash should be above the custom method on line 5',
+        line: 6,
       }],
     },
     {
@@ -132,7 +139,8 @@ eslintTester.run('order-in-routes', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The property should be above the model hook on line 2',
+        line: 3,
       }],
     },
     {
@@ -143,7 +151,8 @@ eslintTester.run('order-in-routes', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The default property should be above the property on line 2',
+        line: 3,
       }],
     },
     {
@@ -154,7 +163,8 @@ eslintTester.run('order-in-routes', rule, {
       });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
-        message: 'Check order of properties',
+        message: 'The model hook should be above the custom method on line 3',
+        line: 4,
       }],
     },
   ]

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -15,75 +15,143 @@ var eslintTester = new RuleTester();
 eslintTester.run('order-in-routes', rule, {
   valid: [
     {
-      code: 'export default Route.extend();',
+      code: `export default Route.extend();`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Route.extend({currentUser: service(), queryParams: {}, customProp: "test", model() {}, beforeModel() {}, actions: {}, _customAction() {}, _customAction2: function() {}, tSomeTask: task(function* () {}) });',
+      code: `export default Route.extend({
+        currentUser: service(),
+        queryParams: {},
+        customProp: "test",
+        model() {},
+        beforeModel() {},
+        actions: {},
+        _customAction() {},
+        _customAction2: function() {},
+        tSomeTask: task(function* () {})
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Route.extend({model() {}, actions: { test() { return this._customAction() } }, _customAction() {} });',
+      code: `export default Route.extend({
+        model() {},
+        actions: { 
+          test() { return this._customAction() }
+        },
+        _customAction() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Route.extend({model() {}, render() {}, init() {} });',
+      code: `export default Route.extend({
+        model() {},
+        render() {},
+        init() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Route.extend({mergedProperties: {}, model() {}, actions: {} });',
+      code: `export default Route.extend({
+        mergedProperties: {},
+        model() {},
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Route.extend({mergedProperties: {}, test: "asd", model() {} });',
+      code: `export default Route.extend({
+        mergedProperties: {},
+        test: "asd",
+        model() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
   ],
   invalid: [
     {
-      code: 'export default Route.extend({queryParams: {}, currentUser: service(), customProp: "test", model() {}, beforeModel() {}, actions: {}, _customAction() {} });',
+      code: `export default Route.extend({
+        queryParams: {},
+        currentUser: service(),
+        customProp: "test",
+        model() {},
+        beforeModel() {},
+        actions: {},
+        _customAction() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Route.extend({customProp: "test", queryParams: {}, model() {}, beforeModel() {}, actions: {}, _customAction() {} });',
+      code: `export default Route.extend({
+        customProp: "test",
+        queryParams: {},
+        model() {},
+        beforeModel() {},
+        actions: {},
+        _customAction() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Route.extend({customProp: "test", queryParams: {}, beforeModel() {}, model() {}, actions: {}, _customAction() {} });',
+      code: `export default Route.extend({
+        customProp: "test",
+        queryParams: {},
+        beforeModel() {},
+        model() {},
+        actions: {},
+        _customAction() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Route.extend({queryParams: {}, customProp: "test", model() {}, _customAction() {}, actions: {} });',
+      code: `export default Route.extend({
+        queryParams: {},
+        customProp: "test",
+        model() {},
+        _customAction() {},
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Route.extend({model() {}, customProp: "test", actions: {} });',
+      code: `export default Route.extend({
+        model() {},
+        customProp: "test",
+        actions: {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Route.extend({test: "asd", mergedProperties: {}, model() {} });',
+      code: `export default Route.extend({
+        test: "asd",
+        mergedProperties: {},
+        model() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',
       }],
     },
     {
-      code: 'export default Route.extend({test: "asd", _test2() {}, model() {} });',
+      code: `export default Route.extend({
+        test: "asd",
+        _test2() {},
+        model() {}
+      });`,
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',


### PR DESCRIPTION
Resolves #13 

Example:

```js
export default Ember.Route.extend({
  foo: 'bar',
  foo2: 'bar',

  setupController() {},

  foo3: 'bar',

  actions: {
    bar() {}
  },

  model() {

  },

  foo4: 'bar',
});
```

```
app/routes/foo.js
   9:3   error  The property should be above the lifecycle hook on line 7    ember/order-in-routes
  15:3   error  The model hook should be above the lifecycle hook on line 7  ember/order-in-routes
  19:3   error  The property should be above the lifecycle hook on line 7    ember/order-in-routes
```
