### PR TITLE
Typo in docs / closure-actions.md

### DIFF
--- a/docs/rules/closure-actions.md
+++ b/docs/rules/closure-actions.md
@@ -22,7 +22,7 @@ export default Controller.extend({
 export default Component.extend({
   actions: {
     pushLever() {
-      this.attr.boom();
+      this.attrs.boom();
     }
   }
 })


### PR DESCRIPTION
Shouldn't this be this.attrs.boom() instead of this.attr.boom()!?