### PR TITLE
27 / Detect module types based on their files' path

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,8 @@ module.exports = {
     'no-use-before-define': 0,
     'no-plusplus': 0,
     'strict': 0,
+    'comma-dangle': [0, {
+      'functions': 'never',
+    }]
   },
 }

--- a/lib/rules/alias-model-in-controller.js
+++ b/lib/rules/alias-model-in-controller.js
@@ -14,9 +14,11 @@ module.exports = function (context) {
     context.report(node, message);
   };
 
+  const filePath = context.getFilename();
+
   return {
     CallExpression(node) {
-      if (!ember.isEmberController(node)) return;
+      if (!ember.isEmberController(node, filePath)) return;
 
       const properties = ember.getModuleProperties(node);
       let aliasPresent = false;

--- a/lib/rules/avoid-leaking-state-in-components.js
+++ b/lib/rules/avoid-leaking-state-in-components.js
@@ -27,6 +27,8 @@ module.exports = {
       context.report(node, message[messageType]);
     };
 
+    const filePath = context.getFilename();
+
     ignoredProperties = ignoredProperties.concat([
       'classNames',
       'classNameBindings',
@@ -39,7 +41,7 @@ module.exports = {
 
     return {
       CallExpression(node) {
-        if (!ember.isEmberComponent(node)) return;
+        if (!ember.isEmberComponent(node, filePath)) return;
 
         const properties = ember.getModuleProperties(node);
 

--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -10,6 +10,8 @@ const utils = require('../utils/utils');
 module.exports = function (context) {
   const message = 'Don\'t use .on() in components';
 
+  const filePath = context.getFilename();
+
   const isOnCall = function (node) {
     const value = node.value;
     const callee = value.callee;
@@ -31,7 +33,7 @@ module.exports = function (context) {
 
   return {
     CallExpression(node) {
-      if (!ember.isEmberComponent(node)) return;
+      if (!ember.isEmberComponent(node, filePath)) return;
 
       const propertiesWithOnCalls = ember.getModuleProperties(node).filter(isOnCall);
 

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -23,10 +23,11 @@ const ORDER = [
 module.exports = function (context) {
   const options = context.options[0] || {};
   const order = options.order || ORDER;
+  const filePath = context.getFilename();
 
   return {
     CallExpression(node) {
-      if (!ember.isEmberComponent(node)) return;
+      if (!ember.isEmberComponent(node, filePath)) return;
 
       reportUnorderedProperties(node, context, 'component', order);
     },

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -24,10 +24,11 @@ const ORDER = [
 module.exports = function (context) {
   const options = context.options[0] || {};
   const order = options.order || ORDER;
+  const filePath = context.getFilename();
 
   return {
     CallExpression(node) {
-      if (!ember.isEmberController(node)) return;
+      if (!ember.isEmberController(node, filePath)) return;
 
       reportUnorderedProperties(node, context, 'controller', order);
     },

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -22,10 +22,11 @@ const ORDER = [
 module.exports = function (context) {
   const options = context.options[0] || {};
   const order = options.order || ORDER;
+  const filePath = context.getFilename();
 
   return {
     CallExpression(node) {
-      if (!ember.isEmberRoute(node)) return;
+      if (!ember.isEmberRoute(node, filePath)) return;
 
       reportUnorderedProperties(node, context, 'route', order);
     },

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -5,6 +5,7 @@ const utils = require('./utils');
 module.exports = {
   isDSModel,
   isModule,
+  isModuleByFilePath,
 
   isEmberComponent,
   isEmberController,
@@ -86,16 +87,30 @@ function isDSModel(node) {
   return isModule(node, 'Model', 'DS');
 }
 
-function isEmberComponent(node) {
-  return isModule(node, 'Component');
+function isModuleByFilePath(filePath, module) {
+  const fileName = `${module}.js`;
+  const folderName = `${module}s`;
+
+  /* Check both folder and filename to support both classic and POD's structure */
+  return filePath.indexOf(fileName) > -1 || filePath.indexOf(folderName) > -1;
 }
 
-function isEmberController(node) {
-  return isModule(node, 'Controller');
+function isEmberComponent(node, filePath) {
+  const isExtended = node.callee.property ? node.callee.property.name === 'extend' : false;
+  const isComponentByFilePath = filePath ? isModuleByFilePath(filePath, 'component') && isExtended : false;
+  return isModule(node, 'Component') || isComponentByFilePath;
 }
 
-function isEmberRoute(node) {
-  return isModule(node, 'Route');
+function isEmberController(node, filePath) {
+  const isExtended = node.callee.property ? node.callee.property.name === 'extend' : false;
+  const isControllerByFilePath = filePath ? isModuleByFilePath(filePath, 'controller') && isExtended : false;
+  return isModule(node, 'Controller') || isControllerByFilePath;
+}
+
+function isEmberRoute(node, filePath) {
+  const isExtended = node.callee.property ? node.callee.property.name === 'extend' : false;
+  const isRouteByFilePath = filePath ? isModuleByFilePath(filePath, 'route') && isExtended : false;
+  return isModule(node, 'Route') || isRouteByFilePath;
 }
 
 function isInjectedServiceProp(node) {

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -7,6 +7,7 @@ module.exports = {
   isModule,
   isModuleByFilePath,
 
+  isEmberCoreModule,
   isEmberComponent,
   isEmberController,
   isEmberRoute,
@@ -95,22 +96,27 @@ function isModuleByFilePath(filePath, module) {
   return filePath.indexOf(fileName) > -1 || filePath.indexOf(folderName) > -1;
 }
 
-function isEmberComponent(node, filePath) {
+function isEmberCoreModule(node, module, filePath) {
   const isExtended = node.callee.property ? node.callee.property.name === 'extend' : false;
-  const isComponentByFilePath = filePath ? isModuleByFilePath(filePath, 'component') && isExtended : false;
-  return isModule(node, 'Component') || isComponentByFilePath;
+  let isModuleByPath;
+
+  if (filePath) {
+    isModuleByPath = isModuleByFilePath(filePath, module.toLowerCase()) && isExtended;
+  }
+
+  return isModule(node, module) || isModuleByPath;
+}
+
+function isEmberComponent(node, filePath) {
+  return isEmberCoreModule(node, 'Component', filePath);
 }
 
 function isEmberController(node, filePath) {
-  const isExtended = node.callee.property ? node.callee.property.name === 'extend' : false;
-  const isControllerByFilePath = filePath ? isModuleByFilePath(filePath, 'controller') && isExtended : false;
-  return isModule(node, 'Controller') || isControllerByFilePath;
+  return isEmberCoreModule(node, 'Controller', filePath);
 }
 
 function isEmberRoute(node, filePath) {
-  const isExtended = node.callee.property ? node.callee.property.name === 'extend' : false;
-  const isRouteByFilePath = filePath ? isModuleByFilePath(filePath, 'route') && isExtended : false;
-  return isModule(node, 'Route') || isRouteByFilePath;
+  return isEmberCoreModule(node, 'Route', filePath);
 }
 
 function isInjectedServiceProp(node) {

--- a/tests/lib/rules/alias-model-in-controller.js
+++ b/tests/lib/rules/alias-model-in-controller.js
@@ -32,6 +32,11 @@ eslintTester.run('alias-model-in-controller', rule, {
       code: 'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model")});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      filename: 'example-app/controllers/path/to/some-feature.js',
+      code: 'export default CustomController.extend({nail: alias("model")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
   ],
   invalid: [
     {
@@ -71,6 +76,30 @@ eslintTester.run('alias-model-in-controller', rule, {
     },
     {
       code: 'export default Ember.Controller.extend(TestMixin, TestMixin2, {});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Alias your model',
+      }],
+    },
+    {
+      filename: 'example-app/controllers/path/to/some-feature.js',
+      code: 'export default CustomController.extend({});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Alias your model',
+      }],
+    },
+    {
+      filename: 'example-app/some-feature/controller.js',
+      code: 'export default CustomController.extend({});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Alias your model',
+      }],
+    },
+    {
+      filename: 'example-app/twisted-path/some-file.js',
+      code: 'export default Controller.extend({});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'Alias your model',

--- a/tests/lib/rules/avoid-leaking-state-in-components.js
+++ b/tests/lib/rules/avoid-leaking-state-in-components.js
@@ -88,5 +88,29 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
         message: 'Avoid using objects as default properties',
       }],
     },
+    {
+      filename: 'example-app/components/some-component.js',
+      code: 'export default CustomComponent.extend({someProp: []});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Avoid using arrays as default properties',
+      }],
+    },
+    {
+      filename: 'example-app/components/some-component/component.js',
+      code: 'export default CustomComponent.extend({someProp: new A()});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Avoid using arrays as default properties',
+      }],
+    },
+    {
+      filename: 'example-app/twisted-path/some-file.js',
+      code: 'export default Component.extend({someProp: {}});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Avoid using objects as default properties',
+      }],
+    },
   ],
 });

--- a/tests/lib/rules/no-on-calls-in-components.js
+++ b/tests/lib/rules/no-on-calls-in-components.js
@@ -84,5 +84,29 @@ eslintTester.run('no-on-calls-in-components', rule, {
         message: 'Don\'t use .on() in components',
       }],
     },
+    {
+      filename: 'example-app/components/some-component/component.js',
+      code: 'export default CustomComponent.extend({test: on("didInsertElement", function () {})});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Don\'t use .on() in components',
+      }],
+    },
+    {
+      filename: 'example-app/components/some-component.js',
+      code: 'export default CustomComponent.extend({test: on("didInsertElement", function () {})});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Don\'t use .on() in components',
+      }],
+    },
+    {
+      filename: 'example-app/twised-path/some-file.js',
+      code: 'export default Component.extend({test: on("didInsertElement", function () {})});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Don\'t use .on() in components',
+      }],
+    },
   ],
 });

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -546,5 +546,41 @@ eslintTester.run('order-in-components', rule, {
         line: 5,
       }],
     },
+    {
+      filename: 'example-app/components/some-component/component.js',
+      code: `export default CustomComponent.extend({
+        actions: {},
+        role: "sloth",
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "role" property should be above the actions hash on line 2',
+        line: 3,
+      }],
+    },
+    {
+      filename: 'example-app/components/some-component.js',
+      code: `export default CustomComponent.extend({
+        actions: {},
+        role: "sloth",
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "role" property should be above the actions hash on line 2',
+        line: 3,
+      }],
+    },
+    {
+      filename: 'example-app/twisted-path/some-component.js',
+      code: `export default Component.extend({
+        actions: {},
+        role: "sloth",
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "role" property should be above the actions hash on line 2',
+        line: 3,
+      }],
+    },
   ],
 });

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -164,5 +164,41 @@ eslintTester.run('order-in-controllers', rule, {
         line: 4,
       }],
     },
+    {
+      filename: 'example-app/controllers/some-controller.js',
+      code: `export default CustomController.extend({
+        queryParams: [],
+        currentUser: service()
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "currentUser" service injection should be above the "queryParams" property on line 2',
+        line: 3,
+      }],
+    },
+    {
+      filename: 'example-app/some-feature/controller.js',
+      code: `export default CustomController.extend({
+        queryParams: [],
+        currentUser: service()
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "currentUser" service injection should be above the "queryParams" property on line 2',
+        line: 3,
+      }],
+    },
+    {
+      filename: 'example-app/twised-path/some-controller.js',
+      code: `export default Controller.extend({
+        queryParams: [],
+        currentUser: service()
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "currentUser" service injection should be above the "queryParams" property on line 2',
+        line: 3,
+      }],
+    },
   ],
 });

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -180,5 +180,41 @@ eslintTester.run('order-in-routes', rule, {
         line: 4,
       }],
     },
+    {
+      filename: 'example-app/routes/some-route.js',
+      code: `export default CustomRoute.extend({
+        model() {},
+        test: "asd",
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "test" property should be above the "model" hook on line 2',
+        line: 3,
+      }],
+    },
+    {
+      filename: 'example-app/some-feature/route.js',
+      code: `export default CustomRoute.extend({
+        model() {},
+        test: "asd",
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "test" property should be above the "model" hook on line 2',
+        line: 3,
+      }],
+    },
+    {
+      filename: 'example-app/twisted-path/some-file.js',
+      code: `export default Route.extend({
+        model() {},
+        test: "asd",
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "test" property should be above the "model" hook on line 2',
+        line: 3,
+      }],
+    },
   ],
 });

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -38,27 +38,134 @@ describe('isDSModel', () => {
   });
 });
 
-describe('isEmberComponent', () => {
-  const node = parse('Ember.Component()');
+describe('isModuleByFilePath', () => {
+  it('should check if current file is a component', () => {
+    const filePath = 'example-app/components/path/to/some-component.js';
+    assert.ok(emberUtils.isModuleByFilePath(filePath, 'component'));
+  });
 
+  it('should check if current file is a component in PODs structure', () => {
+    const filePath = 'example-app/components/path/to/some-component/component.js';
+    assert.ok(emberUtils.isModuleByFilePath(filePath, 'component'));
+  });
+
+  it('should check if current file is a controller', () => {
+    const filePath = 'example-app/controllers/path/to/some-feature.js';
+    assert.ok(emberUtils.isModuleByFilePath(filePath, 'controller'));
+  });
+
+  it('should check if current file is a controller in PODs structure', () => {
+    const filePath = 'example-app/path/to/some-feature/controller.js';
+    assert.ok(emberUtils.isModuleByFilePath(filePath, 'controller'));
+  });
+
+  it('should check if current file is a route', () => {
+    const filePath = 'example-app/routes/path/to/some-feature.js';
+    assert.ok(emberUtils.isModuleByFilePath(filePath, 'route'));
+  });
+
+  it('should check if current file is a route - PODs structure', () => {
+    const filePath = 'example-app/routes/path/to/some-feature/route.js';
+    assert.ok(emberUtils.isModuleByFilePath(filePath, 'route'));
+  });
+});
+
+describe('isEmberComponent', () => {
   it('should check if it\'s an Ember Component', () => {
-    assert.ok(emberUtils.isEmberComponent(node));
+    let node;
+
+    node = parse('Ember.Component.extend()');
+    assert.ok(
+      emberUtils.isEmberComponent(node),
+      'it should detect Component when using Ember.Component'
+    );
+
+    node = parse('Component.extend()');
+    assert.ok(
+      emberUtils.isEmberComponent(node),
+      'it should detect Component when using local module Component'
+    );
+  });
+
+  it('should check if it\'s an Ember Component even if it uses custom name', () => {
+    const node = parse('CustomComponent.extend()');
+    const filePath = 'example-app/components/path/to/some-component.js';
+
+    assert.notOk(
+      emberUtils.isEmberComponent(node),
+      'it shouldn\'t detect Component when no file path is provided'
+    );
+
+    assert.ok(
+      emberUtils.isEmberComponent(node, filePath),
+      'it should detect Component when file path is provided'
+    );
   });
 });
 
 describe('isEmberController', () => {
-  const node = parse('Ember.Controller()');
-
   it('should check if it\'s an Ember Controller', () => {
-    assert.ok(emberUtils.isEmberController(node));
+    let node;
+
+    node = parse('Ember.Controller.extend()');
+    assert.ok(
+      emberUtils.isEmberController(node),
+      'it should detect Controller when using Ember.Controller'
+    );
+
+    node = parse('Controller.extend()');
+    assert.ok(
+      emberUtils.isEmberController(node),
+      'it should detect Controller when using local module Controller'
+    );
+  });
+
+  it('should check if it\'s an Ember Controller even if it uses custom name', () => {
+    const node = parse('CustomController.extend()');
+    const filePath = 'example-app/controllers/path/to/some-feature.js';
+
+    assert.notOk(
+      emberUtils.isEmberController(node),
+      'it shouldn\'t detect Controller when no file path is provided'
+    );
+
+    assert.ok(
+      emberUtils.isEmberController(node, filePath),
+      'it should detect Controller when file path is provided'
+    );
   });
 });
 
 describe('isEmberRoute', () => {
-  const node = parse('Ember.Route()');
-
   it('should check if it\'s an Ember Route', () => {
-    assert.ok(emberUtils.isEmberRoute(node));
+    let node;
+
+    node = parse('Ember.Route.extend()');
+    assert.ok(
+      emberUtils.isEmberRoute(node),
+      'it should detect Route when using Ember.Route'
+    );
+
+    node = parse('Route.extend()');
+    assert.ok(
+      emberUtils.isEmberRoute(node),
+      'it should detect Route when using local module Route'
+    );
+  });
+
+  it('should check if it\'s an Ember Route even if it uses custom name', () => {
+    const node = parse('CustomRoute.extend()');
+    const filePath = 'example-app/routes/path/to/some-feature.js';
+
+    assert.notOk(
+      emberUtils.isEmberRoute(node),
+      'it shouldn\'t detect Route when no file path is provided'
+    );
+
+    assert.ok(
+      emberUtils.isEmberRoute(node, filePath),
+      'it should detect Route when file path is provided'
+    );
   });
 });
 

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -70,6 +70,44 @@ describe('isModuleByFilePath', () => {
   });
 });
 
+describe('isEmberCoreModule', () => {
+  it('should check if current file is a component', () => {
+    const node = parse('CustomComponent.extend()');
+    const filePath = 'example-app/components/path/to/some-component.js';
+    assert.ok(emberUtils.isEmberCoreModule(node, 'component', filePath));
+  });
+
+  it('should check if current file is a component', () => {
+    const node = parse('Component.extend()');
+    const filePath = 'example-app/some-twisted-path/some-component.js';
+    assert.ok(emberUtils.isEmberCoreModule(node, 'component', filePath));
+  });
+
+  it('should check if current file is a controller', () => {
+    const node = parse('CustomController.extend()');
+    const filePath = 'example-app/controllers/path/to/some-controller.js';
+    assert.ok(emberUtils.isEmberCoreModule(node, 'controller', filePath));
+  });
+
+  it('should check if current file is a controller', () => {
+    const node = parse('Controller.extend()');
+    const filePath = 'example-app/some-twisted-path/some-controller.js';
+    assert.ok(emberUtils.isEmberCoreModule(node, 'controller', filePath));
+  });
+
+  it('should check if current file is a route', () => {
+    const node = parse('CustomRoute.extend()');
+    const filePath = 'example-app/routes/path/to/some-route.js';
+    assert.ok(emberUtils.isEmberCoreModule(node, 'route', filePath));
+  });
+
+  it('should check if current file is a route', () => {
+    const node = parse('Route.extend()');
+    const filePath = 'example-app/some-twisted-path/some-route.js';
+    assert.ok(emberUtils.isEmberCoreModule(node, 'route', filePath));
+  });
+});
+
 describe('isEmberComponent', () => {
   it('should check if it\'s an Ember Component', () => {
     let node;


### PR DESCRIPTION
This PR will fix issue called in #27.

Till now checking if node is an Ember Controller, Component or Route depended only on the module name, and it was matched agains something like this: `<Ember.><Module><.*>()`

However there was a problem when someone wanted to extend other module like so:
```
export default CustomComponent.extend({
});
```
Because of the custom component name - eslint rule couldn't guess what exactly is this file and didn't apply any module-related rules on it.

In order to solve this problem I'm also checking file path now. Given examples should be detected as proper modules and all rules should be applied according to their belonging:
```
// example-app/components/some-component.js
export default CustomComponent.extend();

// example-app/components/some-component/component.js
export default CustomComponent.extend();

// example-app/controllers/some-feature.js
export default CustomController.extend();

// example-app/some-feature/controller.js
export default CustomController.extend();

// example-app/routes/some-feature.js
export default CustomRoute.extend();

// example-app/some-feature/route.js
export default CustomRoute.extend();
```

What do you think about this solution @jbandura @netes ? I'm also thinking about improving Model module too.