### PR TITLE
Update no-empty-attrs rule

### DIFF
--- a/lib/rules/no-empty-attrs.js
+++ b/lib/rules/no-empty-attrs.js
@@ -18,13 +18,13 @@ module.exports = function (context) {
       if (!ember.isDSModel(node)) return;
 
       const allProperties = ember.getModuleProperties(node);
-      const propertiesWithEmptyAttrs = allProperties.filter(property =>
-        ember.isModule(property.value, 'attr', 'DS') &&
-        !property.value.arguments.length);
+      const isDSAttr = allProperties.filter(property => ember.isModule(property.value, 'attr', 'DS'));
 
-      if (propertiesWithEmptyAttrs.length) {
-        report(node);
-      }
+      isDSAttr.forEach((attr) => {
+        if (!attr.value.arguments.length) {
+          report(attr.value);
+        }
+      });
     },
   };
 };

--- a/tests/lib/rules/no-empty-attrs.js
+++ b/tests/lib/rules/no-empty-attrs.js
@@ -10,6 +10,8 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester();
+const message = 'Supply proper attribute type';
+
 eslintTester.run('no-empty-attrs', rule, {
   valid: [
     {
@@ -41,18 +43,50 @@ eslintTester.run('no-empty-attrs', rule, {
   ],
   invalid: [
     {
-      code: 'export default Model.extend({name: attr(), points: attr("number"), dob: attr("date")});',
+      code: `export default Model.extend({
+        name: attr(),
+        points: attr("number"),
+        dob: attr("date")
+      });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      errors: [{
-        message: 'Supply proper attribute type',
-      }],
+      errors: [{ message, line: 2 }],
     },
     {
-      code: 'export default Model.extend({name: attr("string"), points: attr("number"), dob: attr()});',
+      code: `export default Model.extend({
+        name: attr("string"),
+        points: attr("number"),
+        dob: attr()
+      });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      errors: [{
-        message: 'Supply proper attribute type',
-      }],
+      errors: [{ message, line: 4 }],
+    },
+    {
+      code: `export default Model.extend({
+        name: attr("string"),
+        points: attr(),
+        dob: attr("date")
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ message, line: 3 }],
+    },
+    {
+      code: `export default Model.extend({
+        name: attr("string"),
+        points: attr(),
+        dob: attr(),
+        someComputedProperty: computed.bool(true)
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ message, line: 3 }, { message, line: 4 }],
+    },
+    {
+      code: `export default Model.extend({
+        name: attr(),
+        points: attr(),
+        dob: attr()
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ message, line: 2 }, { message, line: 3 }, { message, line: 4 }],
     },
   ],
 });


### PR DESCRIPTION
I am introducing this change to the `no-empty-attrs` rule because I have found that it makes more sense to send ESLint report errors on a per-attr property basis. This way, we can use ESLint's inline comments to disable this rule for specific `attr` properties rather than the entire Model.