### PR TITLE
Fix configuration key

### DIFF
--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -5,7 +5,7 @@
 #### Configuration
 
 ```
-ember/order-in-controllers: [2, {
+ember/order-in-models: [2, {
   order: [
     'attribute',
     'relationship',


### PR DESCRIPTION
Was referencing `order-in-controllers` when should reference `order-in-models`.