### PR TITLE
Update no-on-calls-in-components rule

### DIFF
--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -36,7 +36,9 @@ module.exports = function (context) {
       const propertiesWithOnCalls = ember.getModuleProperties(node).filter(isOnCall);
 
       if (propertiesWithOnCalls.length) {
-        report(node);
+        propertiesWithOnCalls.forEach((property) => {
+          report(property.value);
+        });
       }
     },
   };

--- a/tests/lib/rules/no-on-calls-in-components.js
+++ b/tests/lib/rules/no-on-calls-in-components.js
@@ -10,6 +10,8 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester();
+const message = 'Don\'t use .on() in components';
+
 eslintTester.run('no-on-calls-in-components', rule, {
   valid: [
     {
@@ -71,18 +73,30 @@ eslintTester.run('no-on-calls-in-components', rule, {
   ],
   invalid: [
     {
-      code: 'export default Component.extend({test: on("didInsertElement", function () {})});',
+      code: `export default Component.extend({
+        test: on("didInsertElement", function () {})
+      });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      errors: [{
-        message: 'Don\'t use .on() in components',
-      }],
+      errors: [{ message, line: 2 }],
     },
     {
-      code: 'export default Component.extend({test: Ember.on("didInsertElement", function () {})});',
+      code: `export default Component.extend({
+        test: on("init", observer("someProperty", function () {
+          return true;
+        })),
+        someComputedProperty: computed.bool(true)
+      });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      errors: [{
-        message: 'Don\'t use .on() in components',
-      }],
+      errors: [{ message, line: 2 }],
+    },
+    {
+      code: `export default Component.extend({
+        test: Ember.on("didInsertElement", function () {}),
+        someComputedProperty: Ember.computed.readOnly('Hello World!'),
+        anotherTest: Ember.on("willDestroyElement", function () {})
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ message, line: 2 }, { message, line: 4 }],
     },
   ],
 });


### PR DESCRIPTION
This PR updates the `no-on-calls-in-components` rule. I find it more useful to report errors on a per-property basis rather than the entire component. This way, we can take advantage of ESLint's inline comments to disable this rule for specific properties rather than the entire component.