### PR TITLE
Allow concise ArrowFunctionExpression (named-functions-in-promises)

### DIFF
--- a/docs/rules/named-functions-in-promises.md
+++ b/docs/rules/named-functions-in-promises.md
@@ -6,11 +6,12 @@
 
 ```
 ember/named-functions-in-promises: [2, {
-  allowConciseArrow: false,
+  allowSimpleArrowFunction: false,
 }]
 ```
 
-Setting `allowConciseArrow` to `true` allows arrow function expressions that do not have block bodies.
+Setting `allowSimpleArrowFunction` to `true` allows arrow function expressions that do not have block bodies.
+These simple arrow functions must also only contain a single function call.
 For example: `.then(user => this._reloadUser(user))`.
 
 #### Description

--- a/docs/rules/named-functions-in-promises.md
+++ b/docs/rules/named-functions-in-promises.md
@@ -2,6 +2,19 @@
 
 ### Rule name: `named-functions-in-promises`
 
+#### Configuration
+
+```
+ember/named-functions-in-promises: [2, {
+  allowConciseArrow: false,
+}]
+```
+
+Setting `allowConciseArrow` to `true` allows arrow function expressions that do not have block bodies.
+For example: `.then(user => this._reloadUser(user))`.
+
+#### Description
+
 When you use promises and its handlers, use named functions defined on parent object. Thus, you will be able to test them in isolation using unit tests without any additional mocking.
 
 ```javascript

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -28,7 +28,7 @@ module.exports = {
             utils.isFunctionExpression(firstArg) ||
             (
               utils.isArrowFunctionExpression(firstArg) &&
-              !isConciseArrowFunctionExpressionWithParentMethodCall(firstArg)
+              !isConciseArrowFunctionWithCallExpression(firstArg)
             )
           )
         ) {
@@ -44,15 +44,6 @@ module.exports = {
       return utils.isCallExpression(callee.object) &&
         utils.isIdentifier(callee.property) &&
         promisesMethods.indexOf(callee.property.name) > -1;
-    }
-
-    function isConciseArrowFunctionExpressionWithParentMethodCall(node) {
-      if (!isConciseArrowFunctionWithCallExpression(node)) {
-        return false;
-      }
-      const callee = node.body.callee;
-      return utils.isMemberExpression(callee) &&
-        utils.isThisExpression(callee.object);
     }
 
     function isConciseArrowFunctionWithCallExpression(node) {

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -12,6 +12,9 @@ module.exports = {
   },
 
   create(context) {
+    const options = context.options[0] || {};
+    const allowConciseArrow = options.allowConciseArrow || false;
+
     const message = 'Use named functions defined on objects to handle promises';
 
     const report = function (node) {
@@ -22,17 +25,16 @@ module.exports = {
       CallExpression(node) {
         const firstArg = node.arguments[0];
 
-        if (
-          hasPromiseExpression(node) &&
-          (
+        if (hasPromiseExpression(node)) {
+          if (allowConciseArrow && isConciseArrowFunctionWithCallExpression(firstArg)) {
+            return;
+          }
+          if (
             utils.isFunctionExpression(firstArg) ||
-            (
-              utils.isArrowFunctionExpression(firstArg) &&
-              !isConciseArrowFunctionWithCallExpression(firstArg)
-            )
-          )
-        ) {
-          report(node);
+            utils.isArrowFunctionExpression(firstArg)
+          ) {
+            report(node);
+          }
         }
       },
     };

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -26,7 +26,11 @@ module.exports = {
           hasPromiseExpression(node) &&
           (
             utils.isFunctionExpression(firstArg) ||
-            utils.isArrowFunctionExpression(firstArg)
+            utils.isArrowFunctionExpressionWithBody(firstArg) ||
+            (
+              utils.isArrowFunctionExpression(firstArg) &&
+              !utils.isCallExpression(firstArg.body)
+            )
           )
         ) {
           report(node);

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -50,7 +50,7 @@ module.exports = {
       if (!isConciseArrowFunctionWithCallExpression(node)) {
         return false;
       }
-      const { body: { callee } } = node;
+      const callee = node.body.callee;
       return utils.isMemberExpression(callee) &&
         utils.isThisExpression(callee.object);
     }

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -13,7 +13,7 @@ module.exports = {
 
   create(context) {
     const options = context.options[0] || {};
-    const allowConciseArrow = options.allowConciseArrow || false;
+    const allowSimpleArrowFunction = options.allowSimpleArrowFunction || false;
 
     const message = 'Use named functions defined on objects to handle promises';
 
@@ -26,7 +26,10 @@ module.exports = {
         const firstArg = node.arguments[0];
 
         if (hasPromiseExpression(node)) {
-          if (allowConciseArrow && isConciseArrowFunctionWithCallExpression(firstArg)) {
+          if (
+            allowSimpleArrowFunction &&
+            utils.isConciseArrowFunctionWithCallExpression(firstArg)
+          ) {
             return;
           }
           if (
@@ -46,12 +49,6 @@ module.exports = {
       return utils.isCallExpression(callee.object) &&
         utils.isIdentifier(callee.property) &&
         promisesMethods.indexOf(callee.property.name) > -1;
-    }
-
-    function isConciseArrowFunctionWithCallExpression(node) {
-      return utils.isArrowFunctionExpression(node) &&
-        node.expression &&
-        utils.isCallExpression(node.body);
     }
   }
 };

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -26,10 +26,9 @@ module.exports = {
           hasPromiseExpression(node) &&
           (
             utils.isFunctionExpression(firstArg) ||
-            utils.isArrowFunctionExpressionWithBody(firstArg) ||
             (
               utils.isArrowFunctionExpression(firstArg) &&
-              !utils.isCallExpression(firstArg.body)
+              !isConciseArrowFunctionExpressionWithParentMethodCall(firstArg)
             )
           )
         ) {
@@ -45,6 +44,21 @@ module.exports = {
       return utils.isCallExpression(callee.object) &&
         utils.isIdentifier(callee.property) &&
         promisesMethods.indexOf(callee.property.name) > -1;
+    }
+
+    function isConciseArrowFunctionExpressionWithParentMethodCall(node) {
+      if (!isConciseArrowFunctionWithCallExpression(node)) {
+        return false;
+      }
+      const { body: { callee } } = node;
+      return utils.isMemberExpression(callee) &&
+        utils.isThisExpression(callee.object);
+    }
+
+    function isConciseArrowFunctionWithCallExpression(node) {
+      return utils.isArrowFunctionExpression(node) &&
+        node.expression &&
+        utils.isCallExpression(node.body);
     }
   }
 };

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -10,7 +10,6 @@ module.exports = {
   isArrayExpression,
   isFunctionExpression,
   isArrowFunctionExpression,
-  isArrowFunctionExpressionWithBody,
   isNewExpression,
   isCallWithFunctionExpression,
   isThisExpression,
@@ -116,18 +115,6 @@ function isFunctionExpression(node) {
  */
 function isArrowFunctionExpression(node) {
   return node !== undefined && node.type === 'ArrowFunctionExpression';
-}
-
-/**
- * Check whether or not a node is an ArrowFunctionExpression that has a
- * function body.
- *
- * @param {Object} node The node to check.
- * @returns {boolean} Whether or not the node is an ArrowFunctionExpression
- * with a function body.
- */
-function isArrowFunctionExpressionWithBody(node) {
-  return isArrowFunctionExpression(node) && !node.expression;
 }
 
 /**

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -10,6 +10,7 @@ module.exports = {
   isArrayExpression,
   isFunctionExpression,
   isArrowFunctionExpression,
+  isConciseArrowFunctionWithCallExpression,
   isNewExpression,
   isCallWithFunctionExpression,
   isThisExpression,
@@ -115,6 +116,20 @@ function isFunctionExpression(node) {
  */
 function isArrowFunctionExpression(node) {
   return node !== undefined && node.type === 'ArrowFunctionExpression';
+}
+
+/**
+ * Check whether or not a node is an ArrowFunctionExpression with concise body
+ * that contains a call expression.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an ArrowFunctionExpression
+ * with concise body.
+ */
+function isConciseArrowFunctionWithCallExpression(node) {
+  return isArrowFunctionExpression(node) &&
+    node.expression &&
+    isCallExpression(node.body);
 }
 
 /**

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -10,6 +10,7 @@ module.exports = {
   isArrayExpression,
   isFunctionExpression,
   isArrowFunctionExpression,
+  isArrowFunctionExpressionWithBody,
   isNewExpression,
   isCallWithFunctionExpression,
   isThisExpression,
@@ -115,6 +116,18 @@ function isFunctionExpression(node) {
  */
 function isArrowFunctionExpression(node) {
   return node !== undefined && node.type === 'ArrowFunctionExpression';
+}
+
+/**
+ * Check whether or not a node is an ArrowFunctionExpression that has a
+ * function body.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an ArrowFunctionExpression
+ * with a function body.
+ */
+function isArrowFunctionExpressionWithBody(node) {
+  return isArrowFunctionExpression(node) && !node.expression;
 }
 
 /**

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -43,25 +43,25 @@ eslintTester.run('named-functions-in-promises', rule, {
       code: 'user.save().then(() => this._reloadUser(user));',
       parserOptions: { ecmaVersion: 6 },
       options: [{
-        allowConciseArrow: true,
+        allowSimpleArrowFunction: true,
       }],
     }, {
       code: 'user.save().catch(err => this._handleError(err));',
       parserOptions: { ecmaVersion: 6 },
       options: [{
-        allowConciseArrow: true,
+        allowSimpleArrowFunction: true,
       }],
     }, {
       code: 'user.save().finally(() => this._finallyDo());',
       parserOptions: { ecmaVersion: 6 },
       options: [{
-        allowConciseArrow: true,
+        allowSimpleArrowFunction: true,
       }],
     }, {
       code: 'user.save().then(() => user.reload());',
       parserOptions: { ecmaVersion: 6 },
       options: [{
-        allowConciseArrow: true,
+        allowSimpleArrowFunction: true,
       }],
     },
   ],
@@ -81,6 +81,33 @@ eslintTester.run('named-functions-in-promises', rule, {
     }, {
       code: 'user.save().finally(() => {return finallyDo();});',
       parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().then(() => {return user.reload();});',
+      parserOptions: { ecmaVersion: 6 },
+      options: [{
+        allowSimpleArrowFunction: true,
+      }],
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().catch(() => {return error.handle();});',
+      parserOptions: { ecmaVersion: 6 },
+      options: [{
+        allowSimpleArrowFunction: true,
+      }],
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().finally(() => {return finallyDo();});',
+      parserOptions: { ecmaVersion: 6 },
+      options: [{
+        allowSimpleArrowFunction: true,
+      }],
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
@@ -112,7 +139,7 @@ eslintTester.run('named-functions-in-promises', rule, {
       code: 'user.save().then(user => user.name);',
       parserOptions: { ecmaVersion: 6 },
       options: [{
-        allowConciseArrow: true,
+        allowSimpleArrowFunction: true,
       }],
       errors: [{
         message: 'Use named functions defined on objects to handle promises',

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -42,15 +42,27 @@ eslintTester.run('named-functions-in-promises', rule, {
     }, {
       code: 'user.save().then(() => this._reloadUser(user));',
       parserOptions: { ecmaVersion: 6 },
+      options: [{
+        allowConciseArrow: true,
+      }],
     }, {
       code: 'user.save().catch(err => this._handleError(err));',
       parserOptions: { ecmaVersion: 6 },
+      options: [{
+        allowConciseArrow: true,
+      }],
     }, {
       code: 'user.save().finally(() => this._finallyDo());',
       parserOptions: { ecmaVersion: 6 },
+      options: [{
+        allowConciseArrow: true,
+      }],
     }, {
       code: 'user.save().then(() => user.reload());',
       parserOptions: { ecmaVersion: 6 },
+      options: [{
+        allowConciseArrow: true,
+      }],
     },
   ],
   invalid: [
@@ -73,8 +85,35 @@ eslintTester.run('named-functions-in-promises', rule, {
         message: 'Use named functions defined on objects to handle promises',
       }],
     }, {
+      code: 'user.save().then(() => this._reloadUser(user));',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().catch(err => this._handleError(err));',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().finally(() => this._finallyDo());',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().then(() => user.reload());',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
       code: 'user.save().then(user => user.name);',
       parserOptions: { ecmaVersion: 6 },
+      options: [{
+        allowConciseArrow: true,
+      }],
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -48,17 +48,14 @@ eslintTester.run('named-functions-in-promises', rule, {
     }, {
       code: 'user.save().finally(() => this._finallyDo());',
       parserOptions: { ecmaVersion: 6 },
+    }, {
+      code: 'user.save().then(() => user.reload());',
+      parserOptions: { ecmaVersion: 6 },
     },
   ],
   invalid: [
     {
       code: 'user.save().then(() => {return user.reload();});',
-      parserOptions: { ecmaVersion: 6 },
-      errors: [{
-        message: 'Use named functions defined on objects to handle promises',
-      }],
-    }, {
-      code: 'user.save().then(() => user.reload());',
       parserOptions: { ecmaVersion: 6 },
       errors: [{
         message: 'Use named functions defined on objects to handle promises',

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -40,7 +40,7 @@ eslintTester.run('named-functions-in-promises', rule, {
       code: 'user.save().finally(_finallyDo);',
       parserOptions: { ecmaVersion: 6 },
     }, {
-      code: 'user.save().then(() => user.reload());',
+      code: 'user.save().then(() => this._reloadUser(user));',
       parserOptions: { ecmaVersion: 6 },
     }, {
       code: 'user.save().catch(err => this._handleError(err));',
@@ -53,6 +53,12 @@ eslintTester.run('named-functions-in-promises', rule, {
   invalid: [
     {
       code: 'user.save().then(() => {return user.reload();});',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().then(() => user.reload());',
       parserOptions: { ecmaVersion: 6 },
       errors: [{
         message: 'Use named functions defined on objects to handle promises',

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -39,17 +39,20 @@ eslintTester.run('named-functions-in-promises', rule, {
     }, {
       code: 'user.save().finally(_finallyDo);',
       parserOptions: { ecmaVersion: 6 },
+    }, {
+      code: 'user.save().then(() => user.reload());',
+      parserOptions: { ecmaVersion: 6 },
+    }, {
+      code: 'user.save().catch(err => this._handleError(err));',
+      parserOptions: { ecmaVersion: 6 },
+    }, {
+      code: 'user.save().finally(() => this._finallyDo());',
+      parserOptions: { ecmaVersion: 6 },
     },
   ],
   invalid: [
     {
       code: 'user.save().then(() => {return user.reload();});',
-      parserOptions: { ecmaVersion: 6 },
-      errors: [{
-        message: 'Use named functions defined on objects to handle promises',
-      }],
-    }, {
-      code: 'user.save().then(() => user.reload());',
       parserOptions: { ecmaVersion: 6 },
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
@@ -66,6 +69,12 @@ eslintTester.run('named-functions-in-promises', rule, {
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
-    },
+    }, {
+      code: 'user.save().then(user => user.name);',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }
   ],
 });

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -94,6 +94,14 @@ describe('isArrowFunctionExpression', () => {
   });
 });
 
+describe('isConciseArrowFunctionExpressionWithCall', () => {
+  const node = parse('test = () => foo()').right;
+
+  it('should check if node is arrow function expression', () => {
+    assert.ok(utils.isConciseArrowFunctionWithCallExpression(node));
+  });
+});
+
 describe('isNewExpression', () => {
   const node = parse('new Date()');
 

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -97,7 +97,7 @@ describe('isArrowFunctionExpression', () => {
 describe('isConciseArrowFunctionExpressionWithCall', () => {
   const node = parse('test = () => foo()').right;
 
-  it('should check if node is arrow function expression', () => {
+  it('should check if node is concise arrow function expression with call expression body', () => {
     assert.ok(utils.isConciseArrowFunctionWithCallExpression(node));
   });
 });

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -96,9 +96,14 @@ describe('isArrowFunctionExpression', () => {
 
 describe('isConciseArrowFunctionExpressionWithCall', () => {
   const node = parse('test = () => foo()').right;
+  const blockNode = parse('test = () => { foo() }').right;
 
   it('should check if node is concise arrow function expression with call expression body', () => {
     assert.ok(utils.isConciseArrowFunctionWithCallExpression(node));
+  });
+
+  it('should check if node does not have block body', () => {
+    assert.ok(!utils.isConciseArrowFunctionWithCallExpression(blockNode));
   });
 });
 


### PR DESCRIPTION
In relation to #63, this is the change I'm proposing to support binding context using arrow functions while still maintaining while still maintaining testability.

Here's the example for reference:
```javascript
export default Component.extend({
  actions: {
    updateUser(user) {
      user.save()
        .then(user => this._reloadUser(user))
        .then(() => this._notifyAboutSuccess())
        .catch(err => this._notifyAboutFailure(err));
        //  As opposed to:
        // .then(this._reloadUser.bind(this))
        // .then(this._notifyAboutSuccess.bind(this))
        // .catch(this._notifyAboutFailure.bind(this));
    },
  },

  // ... Imagine there's a lot of other functions here ...

  _reloadUser(user) {
    return user.reload();
  },
  _notifyAboutSuccess() { /* ... */ },
  _notifyAboutFailure(err) { /* ... */ },
});
```

Note: This change explicitly allows the concise version of an `ArrowFunctionExpression` and does not allow arrow functions with explicit `() => { /* function bodies */ }`. In addition, it checks to ensure that the expression body is a `CallExpression` to ensure the logic is not happening in the arrow function itself.

Fixes #63