### PR TITLE
Don't use this.attrs in docs

### DIFF
--- a/docs/rules/closure-actions.md
+++ b/docs/rules/closure-actions.md
@@ -22,7 +22,7 @@ export default Controller.extend({
 export default Component.extend({
   actions: {
     pushLever() {
-      this.attrs.boom();
+      get(this, 'boom')();
     }
   }
 })


### PR DESCRIPTION
Per [this recommendation](https://locks.svbtle.com/to-attrs-or-not-to-attrs):

> >The advice to avoid attrs is still relevant as of Ember 2.12, and until angle bracket components are released in Ember.

> tl;dr attrs is a Glimmer Component thing, and Glimmer Components haven’t landed on stable Ember.js yet.

I think think the docs should probably still use `get()` when referring to the passed in attribute.