### PR TITLE
Make it available on emberobserver.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "ember.js",
     "plugin",
     "styleguide",
-    "rules"
+    "rules",
+    "ember-addon"
   ],
   "author": "Michał Sajnóg <michal.sajnog@hotmail.com> (http://github.com/michalsnik)",
   "contributors": [
@@ -54,5 +55,8 @@
   "dependencies": {
     "requireindex": "^1.1.0",
     "snake-case": "^2.1.0"
+  },
+  "ember-addon": {
+    "main": "index.js"
   }
 }


### PR DESCRIPTION
This PR adds keyword `ember-addon` in package.json, so it can appear on emberobserver.com