### PR TITLE
Add a name in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const ember = require(resolve(__dirname, 'lib/utils/ember'));
 const utils = require(resolve(__dirname, 'lib/utils/utils'));
 
 module.exports = {
+  name: 'eslint-plugin-ember',
   rules,
   configs,
   utils: {


### PR DESCRIPTION
I have an error when I try to start ember with eslint-plugin-ember. It gives : 

    An addon must define a `name` property.

My quick fix seems to work.