### PR TITLE
alias-model-in-controller: allow nested properties

### DIFF
--- a/docs/rules/alias-model-in-controller.md
+++ b/docs/rules/alias-model-in-controller.md
@@ -19,3 +19,17 @@ export default Ember.Route.extend({
     controller.set('nail', model);
   },
 });
+```
+
+If you're passing
+[multiple models](https://guides.emberjs.com/v2.13.0/routing/specifying-a-routes-model/#toc_multiple-models) as an
+[`RSVP.hash`](https://emberjs.com/api/classes/RSVP.html#method_hash),
+you can also alias nested properties:
+
+```javascript
+const { reads } = Ember.computed;
+export default Ember.Controller.extend({
+  people: reads('model.people'),
+  pets:   reads('model.pets')
+});
+```

--- a/lib/rules/alias-model-in-controller.js
+++ b/lib/rules/alias-model-in-controller.js
@@ -35,7 +35,10 @@ module.exports = {
           if (
             parsedCallee.length &&
             ['alias', 'readOnly', 'reads'].indexOf(parsedCallee.pop()) > -1 &&
-            parsedArgs[0] === 'model'
+            (
+              parsedArgs[0] === 'model' ||
+              String(parsedArgs[0]).startsWith('model.')
+            )
           ) {
             aliasPresent = true;
           }

--- a/tests/lib/rules/alias-model-in-controller.js
+++ b/tests/lib/rules/alias-model-in-controller.js
@@ -12,6 +12,9 @@ const RuleTester = require('eslint').RuleTester;
 const eslintTester = new RuleTester();
 eslintTester.run('alias-model-in-controller', rule, {
   valid: [
+
+    // direct alias
+
     {
       code: 'export default Ember.Controller.extend({nail: alias("model")});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
@@ -59,6 +62,58 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       filename: 'example-app/controllers/path/to/some-feature.js',
       code: 'export default CustomController.extend({nail: alias("model")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+
+    // nested alias
+
+    {
+      code: 'export default Ember.Controller.extend({nail: alias("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend({nail: computed.alias("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend({nail: Ember.computed.alias("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend({nail: readOnly("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend({nail: computed.readOnly("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend({nail: Ember.computed.readOnly("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend({nail: reads("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend({nail: computed.reads("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend({nail: Ember.computed.reads("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend(TestMixin, {nail: Ember.computed.alias("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model.nail")});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      filename: 'example-app/controllers/path/to/some-feature.js',
+      code: 'export default CustomController.extend({nail: alias("model.nail")});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
   ],


### PR DESCRIPTION
Fixes #79.

You can now do this:

```javascript
 const { reads } = Ember.computed;
 export default Ember.Controller.extend({
   people: reads('model.people'),
   pets:   reads('model.pets')
 });
 ```