### PR TITLE
Fix method of detecting whether route segment present

### DIFF
--- a/lib/rules/routes-segments-snake-case.js
+++ b/lib/rules/routes-segments-snake-case.js
@@ -15,20 +15,21 @@ module.exports = {
 
   create(context) {
     const message = 'Use snake case in dynamic segments of routes';
+    const routeSegmentRegex = /:([a-zA-Z0-9-_]+)/g;
 
     const report = function (node) {
       context.report(node, message);
     };
 
     const isSegment = function (property) {
-      return property.key.name === 'path' && property.value.value.indexOf(':') > -1;
+      return property.key.name === 'path' && routeSegmentRegex.test(property.value.value);
     };
 
     const getSegmentNames = function (property) {
       if (!isSegment(property)) return [];
 
       return property.value.value
-        .match(/:([a-zA-Z0-9-_]+)/g)
+        .match(routeSegmentRegex)
         .map(segment => segment.slice(1));
     };
 

--- a/tests/lib/rules/routes-segments-snake-case.js
+++ b/tests/lib/rules/routes-segments-snake-case.js
@@ -25,6 +25,7 @@ eslintTester.run('routes-segments-snake-case', rule, {
     'this.route("tree", { path: "/test/:tree_id/test_test/:tree_child_id"});',
     'this.route("tree", { path: "/test/:tree_id/test-test/:tree_child_id"});',
     'this.route("tree", { path: "/test/:tree_id/testTest/:tree_child_id"});',
+    'this.route("tree", { path: "*:"});',
   ],
   invalid: [
     {


### PR DESCRIPTION
Resolves #84.

## Problem
If you had a colon symbol in your routes, but it was not at the beginning, it would still try to parse it as a route segment thus resulting in an error, example:
```
this.route('404', { path: '*:' });
```

## Solution
The previous method based on checking presence of `:`. This resulted in problems if for some reason we had the `:` somewhere else, i.e at the end of the string. The fix includes checking this with regex.